### PR TITLE
feat: set colorize default if output_unit is a terminal

### DIFF
--- a/src/veggies/command_line_m.f90
+++ b/src/veggies/command_line_m.f90
@@ -41,7 +41,7 @@ contains
         integer :: iostat
         integer :: num_arguments
 
-        options%colorize_ = .true.
+        options%colorize_ = isatty(output_unit)
         options%quiet_ = .false.
         options%verbose_ = .false.
         options%filter_tests_ = .false.


### PR DESCRIPTION
Otherwise, if output_unit is redirected to a file, turn off colorization

This feature is as promised and as discussed on [fortran-lang.discourse](https://fortran-lang.discourse.group/t/unit-testing-frameworks-for-fortran/6944/18?u=jeff.irwin)

I should note two concerns:

1.  Does this work with nagfor?  I have only tested with gfortran.  Some folks on the forum mentioned ifort also has the `isatty()` function
2. Do you want a `--color-on` option, in case a user wants to force color on even if they are redirecting?  Let me know and I can add that too

If you have portability concerns like # 1, feel free to simply refuse this PR 

Here's what I tested:

- Running `fpm test -- -v` has color *on* by default in the terminal
- Running `fpm test -- -v > public/log.txt` has color *off* by default redirected to a file
- Running `fpm test -- -v --color-off` turns color *off* in the terminal
